### PR TITLE
Update Pytest to version 6.2.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,13 @@ requirements:
     - setuptools >=42.0
     - setuptools_scm >=3.4
     - wheel
+    - toml
   run:
     - python
     - attrs >=19.2.0
     - iniconfig
-    - more-itertools >=4.0.0
     - packaging
-    - pluggy >=0.12,<1.0.0a1
+    - pluggy >=0.12,<2.0
     - py >=1.8.2
     - toml
     - atomicwrites >=1.0  # [win]
@@ -45,6 +45,7 @@ requirements:
 test:
   commands:
     - pytest -h
+    - pip check
   imports:
     - pytest
     - _pytest
@@ -53,6 +54,9 @@ test:
     - _pytest.assertion
     - _pytest.config
     - _pytest.mark
+  requires:
+    - pip
+    - python <3.10
 
 about:
   home: https://docs.pytest.org/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.2.4" %}
+{% set version = "6.2.5" %}
 
 package:
   name: pytest
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pytest/pytest-{{ version }}.tar.gz
-  sha256: 50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b
+  sha256: 131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89
 
 build:
   skip: true  # [py<36]


### PR DESCRIPTION

1. check the upstream
    https://github.com/pytest-dev/pytest/tree/6.2.5

2. check the pinnings
    https://github.com/pytest-dev/pytest/blob/6.2.5/tox.ini
    https://github.com/pytest-dev/pytest/blob/6.2.5/setup.cfg
    https://github.com/pytest-dev/pytest/blob/6.2.5/pyproject.toml

3. check changelogs
    https://github.com/pytest-dev/pytest/blob/6.2.5/CHANGELOG.rst
    https://github.com/pytest-dev/pytest/blob/main/doc/en/changelog.rst

4. additional research
    https://github.com/conda-forge/pytest-feedstock/issues

5. verify dev_url
    https://github.com/pytest-dev/pytest/
6. verify doc_url
    https://docs.pytest.org/en/latest/
7. added pip to the test section
8. verify the test section
9. additional tests


In order to test the `pytest` package version `6.2.5` the following command was used:
`conda build pytest-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `pytest` to version `6.2.5`
