### PR TITLE
pytest 7.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,6 @@ test:
     - astropy
     - jupyter_core
     - pandas
-    - tqdm
 
 about:
   home: https://docs.pytest.org/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,11 +48,6 @@ test:
     - pytest
   requires:
     - pip
-  # 2022/4/4: Make additional downstream testings for the major version bump of pytest to v7.1.1
-  downstreams:
-    - astropy
-    - jupyter_core
-    - pandas
 
 about:
   home: https://docs.pytest.org/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,21 +9,19 @@ source:
   sha256: 841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63
 
 build:
-  skip: true  # [py<36]
-  number: 2
+  skip: true  # [py<37]
+  number: 0
   script: {{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - py.test = py.test:console_main
     - pytest = py.test:console_main
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
   host:
     - pip
     - python
     - setuptools >=42.0
-    - setuptools_scm >=3.4
+    - setuptools_scm >=6.2.3
     - wheel
     - toml
   run:
@@ -33,7 +31,7 @@ requirements:
     - packaging
     - pluggy >=0.12,<2.0
     - py >=1.8.2
-    - toml
+    - tomli >=1.0.0
     - atomicwrites >=1.0  # [win]
     - colorama  # [win]
     - importlib-metadata >=0.12  # [py<38]
@@ -48,15 +46,8 @@ test:
     - pip check
   imports:
     - pytest
-    - _pytest
-    - _pytest._code
-    - _pytest._io
-    - _pytest.assertion
-    - _pytest.config
-    - _pytest.mark
   requires:
     - pip
-    - python <3.10
 
 about:
   home: https://docs.pytest.org/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.2.5" %}
+{% set version = "7.1.1" %}
 
 package:
   name: pytest
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pytest/pytest-{{ version }}.tar.gz
-  sha256: 131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89
+  sha256: 841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63
 
 build:
   skip: true  # [py<36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,12 @@ test:
     - pytest
   requires:
     - pip
+  # 2022/4/4: Make additional downstream testings for the major version bump of pytest to v7.1.1
+  downstreams:
+    - astropy
+    - jupyter_core
+    - pandas
+    - tqdm
 
 about:
   home: https://docs.pytest.org/en/latest/


### PR DESCRIPTION
Update pytest to 7.1.1

Bug tracker: https://github.com/pytest-dev/pytest/issues
Changelog: https://docs.pytest.org/en/stable/changelog.html
License: https://github.com/pytest-dev/pytest/blob/7.1.1/LICENSE
Requirements: 
- https://github.com/pytest-dev/pytest/blob/7.1.1/pyproject.toml
- https://github.com/pytest-dev/pytest/blob/7.1.1/setup.cfg

Actions:
1. Reset build number to 0
2. Skip py<37
3. Remove req/build section
4. Update pinning for `setuptools_scm >=6.2.3`
5. Remove `toml `and replace it with `tomli >=1.0.0` in run
6. Remove private modules from test/imports
7. Remove `python <3.10` from test/requires
8. Add `downstreams `for additional testing
