### PR TITLE
pytest 7.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,16 @@ test:
   commands:
     - pytest -h
     - pip check
+  downstreams:  # [not win]
+    - conda  # [not win]
+    - ipython  # [not win]
+    - jupyter_client  # [not win]
+    - pytest-timeout  # [not win]
+    - pytest-runner  # [not win]
+    - pyzmq  # [not win]
+    - pandas  # [not win]
+    - pytest-cov  # [not win]
+    - pytest-html  # [not win]
 
 about:
   home: https://docs.pytest.org/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,27 @@
-{% set version = "7.1.1" %}
+{% set name = "pytest" %}
+{% set version = "7.1.2" %}
 
 package:
-  name: pytest
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pytest/pytest-{{ version }}.tar.gz
-  sha256: 841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-{{ version }}.tar.gz
+  sha256: a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45
 
 build:
   skip: true  # [py<37]
   number: 0
   script: {{ PYTHON }} setup.py install --single-version-externally-managed --record record.txt
   entry_points:
-    - py.test = py.test:console_main
-    - pytest = py.test:console_main
+    - pytest=pytest:console_main
+    - py.test=pytest:console_main
 
 requirements:
   host:
     - pip
     - python
-    - setuptools >=42.0
+    - setuptools >=45.0
     - setuptools_scm >=6.2.3
     - wheel
     - toml
@@ -41,13 +42,13 @@ requirements:
     - pytest-faulthandler >=2
 
 test:
-  commands:
-    - pytest -h
-    - pip check
   imports:
     - pytest
   requires:
     - pip
+  commands:
+    - pytest -h
+    - pip check
 
 about:
   home: https://docs.pytest.org/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,16 +49,6 @@ test:
   commands:
     - pytest -h
     - pip check
-  downstreams:  # [not win]
-    - conda  # [not win]
-    - ipython  # [not win]
-    - jupyter_client  # [not win]
-    - pytest-timeout  # [not win]
-    - pytest-runner  # [not win]
-    - pyzmq  # [not win]
-    - pandas  # [not win]
-    - pytest-cov  # [not win]
-    - pytest-html  # [not win]
 
 about:
   home: https://docs.pytest.org/en/latest/


### PR DESCRIPTION
Update pytest to 7.1.2

Bug tracker: https://github.com/pytest-dev/pytest/issues
Changelog: **only bugfixes** https://docs.pytest.org/en/stable/changelog.html
License: https://github.com/pytest-dev/pytest/blob/7.1.2/LICENSE
Requirements:

https://github.com/pytest-dev/pytest/blob/7.1.2/pyproject.toml
https://github.com/pytest-dev/pytest/blob/7.1.2/setup.cfg
Actions:

1. Update entry_points
2. Update setuptools pinning