### PR TITLE
Update/7.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - setuptools
     - setuptools_scm >=6.0
     - wheel
-    - toml 0.10.2
   run:
     - python
     - iniconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,15 +43,16 @@ test:
     - pytest
   requires:
     - pip
-    - argcomplete
-    - attrs >=19.2.0
-    - hypothesis >=3.56
-    - mock
-    - nose
-    - pygments >2.7.2
-    - requests
-    - setuptools
-    - xmlschema
+    # For full testing:
+    #- argcomplete
+    #- attrs >=19.2.0
+    #- hypothesis >=3.56
+    #- mock
+    #- nose
+    #- pygments >2.7.2
+    #- requests
+    #- setuptools
+    #- xmlschema
   commands:
     - pytest -h
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest" %}
-{% set version = "7.3.1" %}
+{% set version = "7.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3
+  sha256: b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a
 
 build:
   skip: true  # [py<37]
@@ -22,19 +22,18 @@ requirements:
     - pip
     - python
     - setuptools
-    - setuptools_scm
+    - setuptools_scm >=6.0
     - wheel
     - toml 0.10.2
   run:
     - python
-    - attrs >=19.2.0
     - iniconfig
     - packaging
     - pluggy >=0.12,<2.0
-    - tomli >=1.0.0
     - colorama  # [win]
-    - importlib-metadata >=0.12  # [py<38]
     - exceptiongroup  >=1.0.0  # [py<311]
+    - importlib-metadata >=0.12  # [py<38]
+    - tomli >=1.0.0 # [py<311]
   run_constrained:
     # pytest-faulthandler 2 is a dummy package.
     # if an older version of fault-handler is installed, it will conflict with pytest >=5.
@@ -45,7 +44,15 @@ test:
     - pytest
   requires:
     - pip
+    - argcomplete
     - attrs >=19.2.0
+    - hypothesis >=3.56
+    - mock
+    - nose
+    - pygments >2.7.2
+    - requests
+    - setuptools
+    - xmlschema
   commands:
     - pytest -h
     - pip check


### PR DESCRIPTION
Log:
- Updated version, sha and dependencies
- Added test reqirements but did not invoke full test suite

Requirements file:
https://github.com/pytest-dev/pytest/blob/7.4.0/setup.cfg

Diff from last posted version:
https://github.com/pytest-dev/pytest/compare/7.3.1..7.4.0
TL;DR;
They added `setuptools` to the testing requirments.