### PR TITLE
pytest 8.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest" %}
-{% set version = "8.4.1" %}
+{% set version = "8.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c
+  sha256: 86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01
 
 build:
   skip: true  # [py<39]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-9590](https://anaconda.atlassian.net/browse/PKG-9590)
- [Upstream repository](https://github.com/pytest-dev/pytest/tree/8.4.2)
- [Upstream changelog/diff](https://docs.pytest.org/en/stable/changelog.html)

### Explanation of changes:

- Update version


[PKG-9590]: https://anaconda.atlassian.net/browse/PKG-9590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ