### PR TITLE
v9.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest" %}
-{% set version = "9.0.2" %}
+{% set version = "9.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11
+  sha256: b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
 
 build:
   skip: true  # [py<310]


### PR DESCRIPTION
pytest 9.0.3

**Destination channel:**  defaults

### Links

- [PKG-14407](https://anaconda.atlassian.net/browse/PKG-14407) 
- [Upstream repository](https://github.com/pytest-dev/pytest/tree/9.0.3)
- [Upstream changelog/diff](https://github.com/pytest-dev/pytest/releases/tag/9.0.3)


### Explanation of changes:

- Bump version and SHA

This addresses CVE-2025-71176


[PKG-14407]: https://anaconda.atlassian.net/browse/PKG-14407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ